### PR TITLE
feat: add new attribute reference `zookeeper_connect_string_tls` and variable to configure timeout settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,13 +132,13 @@ Security scanning results provided by Bridgecrew. Bridgecrew is the leading full
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.43 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.60 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.43 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.60 |
 
 ## Modules
 
@@ -200,6 +200,7 @@ No modules.
 | <a name="input_schemas"></a> [schemas](#input\_schemas) | A map schemas to be created within the schema registry | `map(any)` | `{}` | no |
 | <a name="input_scram_secret_association_secret_arn_list"></a> [scram\_secret\_association\_secret\_arn\_list](#input\_scram\_secret\_association\_secret\_arn\_list) | List of AWS Secrets Manager secret ARNs to associate with SCRAM | `list(string)` | `[]` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to assign to the resources created | `map(string)` | `{}` | no |
+| <a name="input_timeouts"></a> [timeouts](#input\_timeouts) | Create, update, and delete timeout configurations for the cluster | `map(string)` | `{}` | no |
 
 ## Outputs
 
@@ -218,6 +219,7 @@ No modules.
 | <a name="output_schemas"></a> [schemas](#output\_schemas) | A map of output attributes for the schemas created |
 | <a name="output_scram_secret_association_id"></a> [scram\_secret\_association\_id](#output\_scram\_secret\_association\_id) | Amazon Resource Name (ARN) of the MSK cluster |
 | <a name="output_zookeeper_connect_string"></a> [zookeeper\_connect\_string](#output\_zookeeper\_connect\_string) | A comma separated list of one or more hostname:port pairs to use to connect to the Apache Zookeeper cluster. The returned values are sorted alphbetically |
+| <a name="output_zookeeper_connect_string_tls"></a> [zookeeper\_connect\_string\_tls](#output\_zookeeper\_connect\_string\_tls) | A comma separated list of one or more hostname:port pairs to use to connect to the Apache Zookeeper cluster via TLS. The returned values are sorted alphbetically |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 
 ## License

--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ No modules.
 | <a name="input_firehose_logs_enabled"></a> [firehose\_logs\_enabled](#input\_firehose\_logs\_enabled) | Indicates whether you want to enable or disable streaming broker logs to Kinesis Data Firehose | `bool` | `false` | no |
 | <a name="input_jmx_exporter_enabled"></a> [jmx\_exporter\_enabled](#input\_jmx\_exporter\_enabled) | Indicates whether you want to enable or disable the JMX Exporter | `bool` | `false` | no |
 | <a name="input_kafka_version"></a> [kafka\_version](#input\_kafka\_version) | Specify the desired Kafka software version | `string` | `null` | no |
-| <a name="input_name"></a> [name](#input\_name) | Name of the MSK cluster | `string` | `""` | no |
+| <a name="input_name"></a> [name](#input\_name) | Name of the MSK cluster | `string` | `"msk"` | no |
 | <a name="input_node_exporter_enabled"></a> [node\_exporter\_enabled](#input\_node\_exporter\_enabled) | Indicates whether you want to enable or disable the Node Exporter | `bool` | `false` | no |
 | <a name="input_number_of_broker_nodes"></a> [number\_of\_broker\_nodes](#input\_number\_of\_broker\_nodes) | The desired total number of broker nodes in the kafka cluster. It must be a multiple of the number of specified client subnets | `number` | `null` | no |
 | <a name="input_s3_logs_bucket"></a> [s3\_logs\_bucket](#input\_s3\_logs\_bucket) | Name of the S3 bucket to deliver logs to | `string` | `null` | no |

--- a/examples/basic/README.md
+++ b/examples/basic/README.md
@@ -23,7 +23,7 @@ Note that this example may create resources which will incur monetary charges on
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.43 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.60 |
 
 ## Providers
 
@@ -61,6 +61,7 @@ No inputs.
 | <a name="output_current_version"></a> [current\_version](#output\_current\_version) | Current version of the MSK Cluster used for updates, e.g. `K13V1IB3VIYZZH` |
 | <a name="output_scram_secret_association_id"></a> [scram\_secret\_association\_id](#output\_scram\_secret\_association\_id) | Amazon Resource Name (ARN) of the MSK cluster |
 | <a name="output_zookeeper_connect_string"></a> [zookeeper\_connect\_string](#output\_zookeeper\_connect\_string) | A comma separated list of one or more hostname:port pairs to use to connect to the Apache Zookeeper cluster. The returned values are sorted alphbetically |
+| <a name="output_zookeeper_connect_string_tls"></a> [zookeeper\_connect\_string\_tls](#output\_zookeeper\_connect\_string\_tls) | A comma separated list of one or more hostname:port pairs to use to connect to the Apache Zookeeper cluster via TLS. The returned values are sorted alphbetically |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 
 Apache-2.0 Licensed. See [LICENSE](../../LICENSE).

--- a/examples/basic/outputs.tf
+++ b/examples/basic/outputs.tf
@@ -43,6 +43,11 @@ output "zookeeper_connect_string" {
   value       = module.msk_cluster.zookeeper_connect_string
 }
 
+output "zookeeper_connect_string_tls" {
+  description = "A comma separated list of one or more hostname:port pairs to use to connect to the Apache Zookeeper cluster via TLS. The returned values are sorted alphbetically"
+  value       = module.msk_cluster.zookeeper_connect_string_tls
+}
+
 # Configuration
 output "configuration_arn" {
   description = "Amazon Resource Name (ARN) of the configuration"

--- a/examples/basic/versions.tf
+++ b/examples/basic/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.43"
+      version = ">= 3.60"
     }
   }
 }

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -22,13 +22,13 @@ Note that this example may create resources which will incur monetary charges on
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.43 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.60 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.43 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.60 |
 | <a name="provider_random"></a> [random](#provider\_random) | n/a |
 
 ## Modules
@@ -71,6 +71,7 @@ No inputs.
 | <a name="output_current_version"></a> [current\_version](#output\_current\_version) | Current version of the MSK Cluster used for updates, e.g. `K13V1IB3VIYZZH` |
 | <a name="output_scram_secret_association_id"></a> [scram\_secret\_association\_id](#output\_scram\_secret\_association\_id) | Amazon Resource Name (ARN) of the MSK cluster |
 | <a name="output_zookeeper_connect_string"></a> [zookeeper\_connect\_string](#output\_zookeeper\_connect\_string) | A comma separated list of one or more hostname:port pairs to use to connect to the Apache Zookeeper cluster. The returned values are sorted alphbetically |
+| <a name="output_zookeeper_connect_string_tls"></a> [zookeeper\_connect\_string\_tls](#output\_zookeeper\_connect\_string\_tls) | A comma separated list of one or more hostname:port pairs to use to connect to the Apache Zookeeper cluster via TLS. The returned values are sorted alphbetically |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 
 Apache-2.0 Licensed. See [LICENSE](../../LICENSE).

--- a/examples/complete/outputs.tf
+++ b/examples/complete/outputs.tf
@@ -43,6 +43,11 @@ output "zookeeper_connect_string" {
   value       = module.msk_cluster.zookeeper_connect_string
 }
 
+output "zookeeper_connect_string_tls" {
+  description = "A comma separated list of one or more hostname:port pairs to use to connect to the Apache Zookeeper cluster via TLS. The returned values are sorted alphbetically"
+  value       = module.msk_cluster.zookeeper_connect_string_tls
+}
+
 # Configuration
 output "configuration_arn" {
   description = "Amazon Resource Name (ARN) of the configuration"

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.43"
+      version = ">= 3.60"
     }
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -86,6 +86,12 @@ resource "aws_msk_cluster" "this" {
     }
   }
 
+  timeouts {
+    create = lookup(var.timeouts, "create", null)
+    update = lookup(var.timeouts, "update", null)
+    delete = lookup(var.timeouts, "delete", null)
+  }
+
   # required for appautoscaling
   lifecycle {
     ignore_changes = [broker_node_group_info[0].ebs_volume_size]

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,64 +1,69 @@
 # Cluster
 output "arn" {
   description = "Amazon Resource Name (ARN) of the MSK cluster"
-  value       = element(concat(aws_msk_cluster.this[*].arn, [""]), 0)
+  value       = try(aws_msk_cluster.this[0].arn, "")
 }
 
 output "bootstrap_brokers" {
   description = "Comma separated list of one or more hostname:port pairs of kafka brokers suitable to bootstrap connectivity to the kafka cluster"
-  value = element(concat(compact([
-    element(concat(aws_msk_cluster.this[*].bootstrap_brokers, [""]), 0),
-    element(concat(aws_msk_cluster.this[*].bootstrap_brokers_sasl_iam, [""]), 0),
-    element(concat(aws_msk_cluster.this[*].bootstrap_brokers_sasl_scram, [""]), 0),
-    element(concat(aws_msk_cluster.this[*].bootstrap_brokers_tls, [""]), 0),
-  ]), [""]), 0)
+  value = compact([
+    try(aws_msk_cluster.this[0].bootstrap_brokers, ""),
+    try(aws_msk_cluster.this[0].bootstrap_brokers_sasl_iam, ""),
+    try(aws_msk_cluster.this[0].bootstrap_brokers_sasl_scram, ""),
+    try(aws_msk_cluster.this[0].bootstrap_brokers_tls, ""),
+  ])
 }
 
 output "bootstrap_brokers_plaintext" {
   description = "Comma separated list of one or more hostname:port pairs of kafka brokers suitable to bootstrap connectivity to the kafka cluster. Contains a value if `encryption_in_transit_client_broker` is set to `PLAINTEXT` or `TLS_PLAINTEXT`"
-  value       = element(concat(aws_msk_cluster.this[*].bootstrap_brokers, [""]), 0)
+  value       = try(aws_msk_cluster.this[0].bootstrap_brokers, "")
 }
 
 output "bootstrap_brokers_sasl_iam" {
   description = "One or more DNS names (or IP addresses) and SASL IAM port pairs. This attribute will have a value if `encryption_in_transit_client_broker` is set to `TLS_PLAINTEXT` or `TLS` and `client_authentication_sasl_iam` is set to `true`"
-  value       = element(concat(aws_msk_cluster.this[*].bootstrap_brokers_sasl_iam, [""]), 0)
+  value       = try(aws_msk_cluster.this[0].bootstrap_brokers_sasl_iam, "")
 }
 
 output "bootstrap_brokers_sasl_scram" {
   description = "One or more DNS names (or IP addresses) and SASL SCRAM port pairs. This attribute will have a value if `encryption_in_transit_client_broker` is set to `TLS_PLAINTEXT` or `TLS` and `client_authentication_sasl_scram` is set to `true`"
-  value       = element(concat(aws_msk_cluster.this[*].bootstrap_brokers_sasl_scram, [""]), 0)
+  value       = try(aws_msk_cluster.this[0].bootstrap_brokers_sasl_scram, "")
 }
 
 output "bootstrap_brokers_tls" {
   description = "One or more DNS names (or IP addresses) and TLS port pairs. This attribute will have a value if `encryption_in_transit_client_broker` is set to `TLS_PLAINTEXT` or `TLS`"
-  value       = element(concat(aws_msk_cluster.this[*].bootstrap_brokers_tls, [""]), 0)
+  value       = try(aws_msk_cluster.this[0].bootstrap_brokers_tls, "")
 }
 
 output "current_version" {
   description = "Current version of the MSK Cluster used for updates, e.g. `K13V1IB3VIYZZH`"
-  value       = element(concat(aws_msk_cluster.this[*].current_version, [""]), 0)
+  value       = try(aws_msk_cluster.this[0].current_version, "")
 }
 
 output "zookeeper_connect_string" {
   description = "A comma separated list of one or more hostname:port pairs to use to connect to the Apache Zookeeper cluster. The returned values are sorted alphbetically"
-  value       = element(concat(aws_msk_cluster.this[*].zookeeper_connect_string, [""]), 0)
+  value       = try(aws_msk_cluster.this[0].zookeeper_connect_string, "")
+}
+
+output "zookeeper_connect_string_tls" {
+  description = "A comma separated list of one or more hostname:port pairs to use to connect to the Apache Zookeeper cluster via TLS. The returned values are sorted alphbetically"
+  value       = try(aws_msk_cluster.this[0].zookeeper_connect_string_tls, "")
 }
 
 # Configuration
 output "configuration_arn" {
   description = "Amazon Resource Name (ARN) of the configuration"
-  value       = element(concat(aws_msk_configuration.this[*].arn, [""]), 0)
+  value       = try(aws_msk_configuration.this[0].arn, "")
 }
 
 output "configuration_latest_revision" {
   description = "Latest revision of the configuration"
-  value       = element(concat(aws_msk_configuration.this[*].latest_revision, [""]), 0)
+  value       = try(aws_msk_configuration.this[0].latest_revision, "")
 }
 
 # SCRAM secret association
 output "scram_secret_association_id" {
   description = "Amazon Resource Name (ARN) of the MSK cluster"
-  value       = element(concat(aws_msk_scram_secret_association.this[*].id, [""]), 0)
+  value       = try(aws_msk_scram_secret_association.this[0].id, "")
 }
 
 # Schema registry

--- a/variables.tf
+++ b/variables.tf
@@ -137,6 +137,12 @@ variable "s3_logs_prefix" {
   default     = null
 }
 
+variable "timeouts" {
+  description = "Create, update, and delete timeout configurations for the cluster"
+  type        = map(string)
+  default     = {}
+}
+
 variable "tags" {
   description = "A map of tags to assign to the resources created"
   type        = map(string)

--- a/variables.tf
+++ b/variables.tf
@@ -8,7 +8,7 @@ variable "create" {
 variable "name" {
   description = "Name of the MSK cluster"
   type        = string
-  default     = ""
+  default     = "msk" # to avoid: Error: cluster_name must be 1 characters or higher
 }
 
 variable "kafka_version" {

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.43"
+      version = ">= 3.60"
     }
   }
 }


### PR DESCRIPTION
## Description
- add new attribute reference `zookeeper_connect_string_tls`
- add new variable `timeouts` to configure timeout settings (create, update, delete)
- bump min supported version to support these changes
- add default cluster name of `msk` to avoid errors `Error: cluster_name must be 1 characters or higher (aws_msk_cluster_invalid_cluster_name)`

## Motivation and Context
- add changes from upstream AWS provider in release [v3.60.0](https://github.com/hashicorp/terraform-provider-aws/blob/main/CHANGELOG.md#3600-september-23-2021)
- to avoid errors `Error: cluster_name must be 1 characters or higher (aws_msk_cluster_invalid_cluster_name)`

## How Has This Been Tested?
- tested using complete example

## Screenshots (if appropriate):
