### PR TITLE
feat!: Update AWS provider to v5.0, replace `ebs_volume_size` attribute

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -8,6 +8,7 @@ on:
 
 env:
   TERRAFORM_DOCS_VERSION: v0.16.0
+  TFLINT_VERSION: v0.44.1
 
 jobs:
   collectInputs:
@@ -17,11 +18,11 @@ jobs:
       directories: ${{ steps.dirs.outputs.directories }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Get root directories
         id: dirs
-        uses: clowdhaus/terraform-composite-actions/directories@v1.4.0
+        uses: clowdhaus/terraform-composite-actions/directories@v1.8.3
 
   preCommitMinVersions:
     name: Min TF pre-commit
@@ -32,28 +33,30 @@ jobs:
         directory: ${{ fromJson(needs.collectInputs.outputs.directories) }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Terraform min/max versions
         id: minMax
-        uses: clowdhaus/terraform-min-max@v1.0.4
+        uses: clowdhaus/terraform-min-max@v1.2.4
         with:
           directory: ${{ matrix.directory }}
 
       - name: Pre-commit Terraform ${{ steps.minMax.outputs.minVersion }}
         # Run only validate pre-commit check on min version supported
         if: ${{ matrix.directory !=  '.' }}
-        uses: clowdhaus/terraform-composite-actions/pre-commit@v1.4.0
+        uses: clowdhaus/terraform-composite-actions/pre-commit@v1.8.3
         with:
           terraform-version: ${{ steps.minMax.outputs.minVersion }}
+          tflint-version: ${{ env.TFLINT_VERSION }}
           args: 'terraform_validate --color=always --show-diff-on-failure --files ${{ matrix.directory }}/*'
 
       - name: Pre-commit Terraform ${{ steps.minMax.outputs.minVersion }}
         # Run only validate pre-commit check on min version supported
         if: ${{ matrix.directory ==  '.' }}
-        uses: clowdhaus/terraform-composite-actions/pre-commit@v1.4.0
+        uses: clowdhaus/terraform-composite-actions/pre-commit@v1.8.3
         with:
           terraform-version: ${{ steps.minMax.outputs.minVersion }}
+          tflint-version: ${{ env.TFLINT_VERSION }}
           args: 'terraform_validate --color=always --show-diff-on-failure --files $(ls *.tf)'
 
   preCommitMaxVersion:
@@ -62,17 +65,19 @@ jobs:
     needs: collectInputs
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{github.event.pull_request.head.repo.full_name}}
 
       - name: Terraform min/max versions
         id: minMax
-        uses: clowdhaus/terraform-min-max@v1.0.4
+        uses: clowdhaus/terraform-min-max@v1.2.4
 
       - name: Pre-commit Terraform ${{ steps.minMax.outputs.maxVersion }}
-        uses: clowdhaus/terraform-composite-actions/pre-commit@v1.4.0
+        uses: clowdhaus/terraform-composite-actions/pre-commit@v1.8.3
         with:
           terraform-version: ${{ steps.minMax.outputs.maxVersion }}
+          tflint-version: ${{ env.TFLINT_VERSION }}
           terraform-docs-version: ${{ env.TERRAFORM_DOCS_VERSION }}
+          install-hcledit: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.62.3
+    rev: v1.81.0
     hooks:
       - id: terraform_fmt
       - id: terraform_validate
@@ -23,7 +23,7 @@ repos:
           - '--args=--only=terraform_standard_module_structure'
           - '--args=--only=terraform_workspace_remote'
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.1.0
+    rev: v4.4.0
     hooks:
       - id: check-merge-conflict
       - id: end-of-file-fixer

--- a/README.md
+++ b/README.md
@@ -11,12 +11,14 @@ module "msk_kafka_cluster" {
   source = "clowdhaus/msk-kafka-cluster/aws"
 
   name                   = local.name
-  kafka_version          = "2.8.0"
+  kafka_version          = "3.4.0"
   number_of_broker_nodes = 3
   enhanced_monitoring    = "PER_TOPIC_PER_PARTITION"
 
-  broker_node_client_subnets  = ["subnet-12345678", "subnet-024681012", "subnet-87654321"]
-  broker_node_ebs_volume_size = 20
+  broker_node_client_subnets = ["subnet-12345678", "subnet-024681012", "subnet-87654321"]
+  broker_node_storage_info = {
+    ebs_storage_info = { volume_size = 100 }
+  }
   broker_node_instance_type   = "kafka.t3.small"
   broker_node_security_groups = ["sg-12345678"]
 
@@ -40,8 +42,10 @@ module "msk_kafka_cluster" {
   scaling_max_capacity = 512
   scaling_target_value = 80
 
-  client_authentication_sasl_scram         = true
-  create_scram_secret_association          = true
+  client_authentication = {
+    sasl = { scram = true }
+  }
+  create_scram_secret_association = true
   scram_secret_association_secret_arn_list = [
     aws_secretsmanager_secret.one.arn,
     aws_secretsmanager_secret.two.arn,
@@ -75,25 +79,30 @@ module "msk_kafka_cluster" {
       description          = "Schema that contains all the records"
       compatibility        = "FORWARD"
       team_b_records = {
-      schema_registry_name = "team_b"
-      schema_name          = "records"
-      description          = "Schema that contains all the records"
-      compatibility        = "FORWARD"
-      schema_definition = jsonencode({
-        type = "record"
-        name = "r1"
-        fields = [{
-          name = "f1"
-          type = "int"
-          }, {
-          name = "f2"
-          type = "string"
-          }, {
-          name = "f3"
-          type = "boolean"
-        }]
-      })
-      tags = { Team = "Team B" }
+        schema_registry_name = "team_b"
+        schema_name          = "records"
+        description          = "Schema that contains all the records"
+        compatibility        = "FORWARD"
+        schema_definition = jsonencode({
+          type = "record"
+          name = "r1"
+          fields = [
+            {
+              name = "f1"
+              type = "int"
+            },
+            {
+              name = "f2"
+              type = "string"
+            },
+            {
+              name = "f3"
+              type = "boolean"
+            }
+          ]
+        })
+        tags = { Team = "Team B" }
+      }
     }
   }
 
@@ -111,34 +120,19 @@ Examples codified under the [`examples`](https://github.com/clowdhaus/terraform-
 - [Basic](https://github.com/clowdhaus/terraform-aws-msk-kafka-cluster/tree/main/examples/basic)
 - [Complete](https://github.com/clowdhaus/terraform-aws-msk-kafka-cluster/tree/main/examples/complete)
 
-## Security & Compliance [<img src="https://raw.githubusercontent.com/clowdhaus/terraform-aws-msk-kafka-cluster/main/.github/images/bridgecrew.svg" width="250" align="right" />](https://bridgecrew.io/)
-
-Security scanning results provided by Bridgecrew. Bridgecrew is the leading fully hosted, cloud-native solution providing continuous Terraform security and compliance.
-
-| Benchmark | Description |
-|--------|---------------|
-| [![Infrastructure Tests](https://www.bridgecrew.cloud/badges/github/clowdhaus/terraform-aws-msk-kafka-cluster/general)](https://www.bridgecrew.cloud/link/badge?vcs=github&fullRepo=clowdhaus%2Fterraform-aws-msk-kafka-cluster&benchmark=INFRASTRUCTURE+SECURITY) | Infrastructure Security Compliance |
-| [![Infrastructure Tests](https://www.bridgecrew.cloud/badges/github/clowdhaus/terraform-aws-msk-kafka-cluster/cis_aws)](https://www.bridgecrew.cloud/link/badge?vcs=github&fullRepo=clowdhaus%2Fterraform-aws-msk-kafka-cluster&benchmark=CIS+AWS+V1.2) | Center for Internet Security, AWS Compliance |
-| [![Infrastructure Tests](https://www.bridgecrew.cloud/badges/github/clowdhaus/terraform-aws-msk-kafka-cluster/pci_dss_v321)](https://www.bridgecrew.cloud/link/badge?vcs=github&fullRepo=clowdhaus%2Fterraform-aws-msk-kafka-cluster&benchmark=PCI-DSS+V3.2.1) | Payment Card Industry Data Security Standards Compliance |
-| [![Infrastructure Tests](https://www.bridgecrew.cloud/badges/github/clowdhaus/terraform-aws-msk-kafka-cluster/nist)](https://www.bridgecrew.cloud/link/badge?vcs=github&fullRepo=clowdhaus%2Fterraform-aws-msk-kafka-cluster&benchmark=NIST-800-53) | National Institute of Standards and Technology Compliance |
-| [![Infrastructure Tests](https://www.bridgecrew.cloud/badges/github/clowdhaus/terraform-aws-msk-kafka-cluster/iso)](https://www.bridgecrew.cloud/link/badge?vcs=github&fullRepo=clowdhaus%2Fterraform-aws-msk-kafka-cluster&benchmark=ISO27001) | Information Security Management System, ISO/IEC 27001 Compliance |
-| [![Infrastructure Tests](https://www.bridgecrew.cloud/badges/github/clowdhaus/terraform-aws-msk-kafka-cluster/soc2)](https://www.bridgecrew.cloud/link/badge?vcs=github&fullRepo=clowdhaus%2Fterraform-aws-msk-kafka-cluster&benchmark=SOC2) | Service Organization Control 2 Compliance |
-| [![Infrastructure Tests](https://www.bridgecrew.cloud/badges/github/clowdhaus/terraform-aws-msk-kafka-cluster/hipaa)](https://www.bridgecrew.cloud/link/badge?vcs=github&fullRepo=clowdhaus%2Fterraform-aws-msk-kafka-cluster&benchmark=HIPAA) | Health Insurance Portability and Accountability Compliance |
-| [![Infrastructure Tests](https://www.bridgecrew.cloud/badges/github/clowdhaus/terraform-aws-msk-kafka-cluster/fedramp_moderate)](https://www.bridgecrew.cloud/link/badge?vcs=github&fullRepo=clowdhaus%2Fterraform-aws-msk-kafka-cluster&benchmark=FEDRAMP+%28MODERATE%29) | FedRAMP Moderate Impact Level |
-
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Requirements
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.71 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.71 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.0 |
 
 ## Modules
 
@@ -163,19 +157,21 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_broker_node_az_distribution"></a> [broker\_node\_az\_distribution](#input\_broker\_node\_az\_distribution) | The distribution of broker nodes across availability zones ([documentation](https://docs.aws.amazon.com/msk/1.0/apireference/clusters.html#clusters-model-brokerazdistribution)). Currently the only valid value is `DEFAULT` | `string` | `null` | no |
 | <a name="input_broker_node_client_subnets"></a> [broker\_node\_client\_subnets](#input\_broker\_node\_client\_subnets) | A list of subnets to connect to in client VPC ([documentation](https://docs.aws.amazon.com/msk/1.0/apireference/clusters.html#clusters-prop-brokernodegroupinfo-clientsubnets)) | `list(string)` | `[]` | no |
-| <a name="input_broker_node_ebs_volume_size"></a> [broker\_node\_ebs\_volume\_size](#input\_broker\_node\_ebs\_volume\_size) | The size in GiB of the EBS volume for the data drive on each broker node | `number` | `null` | no |
+| <a name="input_broker_node_connectivity_info"></a> [broker\_node\_connectivity\_info](#input\_broker\_node\_connectivity\_info) | Information about the cluster access configuration | `any` | `{}` | no |
 | <a name="input_broker_node_instance_type"></a> [broker\_node\_instance\_type](#input\_broker\_node\_instance\_type) | Specify the instance type to use for the kafka brokers. e.g. kafka.m5.large. ([Pricing info](https://aws.amazon.com/msk/pricing/)) | `string` | `null` | no |
 | <a name="input_broker_node_security_groups"></a> [broker\_node\_security\_groups](#input\_broker\_node\_security\_groups) | A list of the security groups to associate with the elastic network interfaces to control who can communicate with the cluster | `list(string)` | `[]` | no |
-| <a name="input_client_authentication_sasl_iam"></a> [client\_authentication\_sasl\_iam](#input\_client\_authentication\_sasl\_iam) | Enables IAM client authentication | `bool` | `false` | no |
-| <a name="input_client_authentication_sasl_scram"></a> [client\_authentication\_sasl\_scram](#input\_client\_authentication\_sasl\_scram) | Enables SCRAM client authentication via AWS Secrets Manager | `bool` | `false` | no |
-| <a name="input_client_authentication_tls_certificate_authority_arns"></a> [client\_authentication\_tls\_certificate\_authority\_arns](#input\_client\_authentication\_tls\_certificate\_authority\_arns) | List of ACM Certificate Authority Amazon Resource Names (ARNs) | `list(string)` | `[]` | no |
+| <a name="input_broker_node_storage_info"></a> [broker\_node\_storage\_info](#input\_broker\_node\_storage\_info) | A block that contains information about storage volumes attached to MSK broker nodes | `any` | `{}` | no |
+| <a name="input_client_authentication"></a> [client\_authentication](#input\_client\_authentication) | Configuration block for specifying a client authentication | `any` | `{}` | no |
 | <a name="input_cloudwatch_log_group_kms_key_id"></a> [cloudwatch\_log\_group\_kms\_key\_id](#input\_cloudwatch\_log\_group\_kms\_key\_id) | The ARN of the KMS Key to use when encrypting log data | `string` | `null` | no |
 | <a name="input_cloudwatch_log_group_name"></a> [cloudwatch\_log\_group\_name](#input\_cloudwatch\_log\_group\_name) | Name of the Cloudwatch Log Group to deliver logs to | `string` | `null` | no |
 | <a name="input_cloudwatch_log_group_retention_in_days"></a> [cloudwatch\_log\_group\_retention\_in\_days](#input\_cloudwatch\_log\_group\_retention\_in\_days) | Specifies the number of days you want to retain log events in the log group | `number` | `0` | no |
 | <a name="input_cloudwatch_logs_enabled"></a> [cloudwatch\_logs\_enabled](#input\_cloudwatch\_logs\_enabled) | Indicates whether you want to enable or disable streaming broker logs to Cloudwatch Logs | `bool` | `false` | no |
+| <a name="input_configuration_arn"></a> [configuration\_arn](#input\_configuration\_arn) | ARN of an externally created configuration to use | `string` | `null` | no |
 | <a name="input_configuration_description"></a> [configuration\_description](#input\_configuration\_description) | Description of the configuration | `string` | `null` | no |
 | <a name="input_configuration_name"></a> [configuration\_name](#input\_configuration\_name) | Name of the configuration | `string` | `null` | no |
+| <a name="input_configuration_revision"></a> [configuration\_revision](#input\_configuration\_revision) | Revision of the externally created configuration to use | `number` | `null` | no |
 | <a name="input_configuration_server_properties"></a> [configuration\_server\_properties](#input\_configuration\_server\_properties) | Contents of the server.properties file. Supported properties are documented in the [MSK Developer Guide](https://docs.aws.amazon.com/msk/latest/developerguide/msk-configuration-properties.html) | `map(string)` | `{}` | no |
 | <a name="input_connect_custom_plugin_timeouts"></a> [connect\_custom\_plugin\_timeouts](#input\_connect\_custom\_plugin\_timeouts) | Timeout configurations for the connect custom plugins | `map(string)` | <pre>{<br>  "create": null<br>}</pre> | no |
 | <a name="input_connect_custom_plugins"></a> [connect\_custom\_plugins](#input\_connect\_custom\_plugins) | Map of custom plugin configuration details (map of maps) | `any` | `{}` | no |
@@ -184,6 +180,7 @@ No modules.
 | <a name="input_connect_worker_config_properties_file_content"></a> [connect\_worker\_config\_properties\_file\_content](#input\_connect\_worker\_config\_properties\_file\_content) | Contents of connect-distributed.properties file. The value can be either base64 encoded or in raw format | `string` | `null` | no |
 | <a name="input_create"></a> [create](#input\_create) | Determines whether cluster resources will be created | `bool` | `true` | no |
 | <a name="input_create_cloudwatch_log_group"></a> [create\_cloudwatch\_log\_group](#input\_create\_cloudwatch\_log\_group) | Determines whether to create a CloudWatch log group | `bool` | `true` | no |
+| <a name="input_create_configuration"></a> [create\_configuration](#input\_create\_configuration) | Determines whether to create a configuration | `bool` | `true` | no |
 | <a name="input_create_connect_worker_configuration"></a> [create\_connect\_worker\_configuration](#input\_create\_connect\_worker\_configuration) | Determines whether to create connect worker configuration | `bool` | `false` | no |
 | <a name="input_create_schema_registry"></a> [create\_schema\_registry](#input\_create\_schema\_registry) | Determines whether to create a Glue schema registry for managing Avro schemas for the cluster | `bool` | `true` | no |
 | <a name="input_create_scram_secret_association"></a> [create\_scram\_secret\_association](#input\_create\_scram\_secret\_association) | Determines whether to create SASL/SCRAM secret association | `bool` | `false` | no |
@@ -207,6 +204,7 @@ No modules.
 | <a name="input_schema_registries"></a> [schema\_registries](#input\_schema\_registries) | A map of schema registries to be created | `map(any)` | `{}` | no |
 | <a name="input_schemas"></a> [schemas](#input\_schemas) | A map schemas to be created within the schema registry | `map(any)` | `{}` | no |
 | <a name="input_scram_secret_association_secret_arn_list"></a> [scram\_secret\_association\_secret\_arn\_list](#input\_scram\_secret\_association\_secret\_arn\_list) | List of AWS Secrets Manager secret ARNs to associate with SCRAM | `list(string)` | `[]` | no |
+| <a name="input_storage_mode"></a> [storage\_mode](#input\_storage\_mode) | Controls storage mode for supported storage tiers. Valid values are: `LOCAL` or `TIERED` | `string` | `null` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to assign to the resources created | `map(string)` | `{}` | no |
 | <a name="input_timeouts"></a> [timeouts](#input\_timeouts) | Create, update, and delete timeout configurations for the cluster | `map(string)` | `{}` | no |
 

--- a/UPGRADE-2.0.md
+++ b/UPGRADE-2.0.md
@@ -127,4 +127,3 @@ module "msk_kafka_cluster" {
 ### State Move Commands
 
 No Terraform state manipulation is required for this upgrade.
-

--- a/UPGRADE-2.0.md
+++ b/UPGRADE-2.0.md
@@ -1,0 +1,130 @@
+# Upgrade from v1.x to v2.x
+
+Please consult the `examples` directory for reference example configurations. If you find a bug, please open an issue with supporting configuration to reproduce.
+
+## Backwards incompatible changes
+
+- Terraform AWS provider minimum supported version raised to `v5.0`
+- Terraform minimum supported version raised to `v1.0`
+- `broker_node_ebs_volume_size` has been removed since the `ebs_volume_size` argument was removed in `v5.0` of the AWS provider. Instead, storage settings should be configured using the `broker_node_storage_info` variable.
+- `client_authentication_*` variables have been removed and replaced with `client_authentication` which supports the various authentication methods and configurations
+
+## Additional changes
+
+### Added
+
+- None
+
+### Modified
+
+- Users can now utilize an externally created configuration by using the `create_configuration`, `configuration_arn`, and `configuration_revision` variables.
+
+### Removed
+
+- None
+
+### Variable and output changes
+
+1. Removed variables:
+
+    - `broker_node_ebs_volume_size` -> replaced by `broker_node_storage_info`
+    - `client_authentication_tls_certificate_authority_arns`-> replaced by `client_authentication`
+    - `client_authentication_sasl_iam` -> replaced by `client_authentication`
+    - `client_authentication_sasl_scram` -> replaced by `client_authentication`
+
+2. Renamed variables:
+
+    - None
+
+3. Added variables:
+
+    - `storage_mode`
+    - `create_configuration`
+    - `configuration_arn`
+    - `configuration_revision`
+
+4. Removed outputs:
+
+    - None
+
+5. Renamed outputs:
+
+    - None
+
+6. Added outputs:
+
+    - None
+
+## Upgrade Migrations
+
+Note: Only the relevant changes are shown for brevity
+
+### Before - v1.2 Example
+
+```hcl
+module "msk_kafka_cluster" {
+  source  = "clowdhaus/msk-kafka-cluster/aws"
+  version = "1.2"
+
+  broker_node_ebs_volume_size = 20
+
+  client_authentication_sasl_scram = true
+
+  tags = {
+    Blueprint  = local.name
+    GithubRepo = "github.com/clowdhaus/terraform-aws-msk-kafka-cluster"
+  }
+}
+```
+
+### After - v2.0 Example
+
+```hcl
+module "msk_kafka_cluster" {
+  source  = "clowdhaus/msk-kafka-cluster/aws"
+  version = "2.0"
+
+  broker_node_storage_info = {
+    ebs_storage_info = { volume_size = 20 }
+  }
+
+  client_authentication = {
+    sasl = { scram = true }
+  }
+
+  tags = {
+    Blueprint  = local.name
+    GithubRepo = "github.com/clowdhaus/terraform-aws-msk-kafka-cluster"
+  }
+}
+```
+
+### Diff of Before vs After
+
+```diff
+module "msk_kafka_cluster" {
+  source  = "clowdhaus/msk-kafka-cluster/aws"
+-  version = "1.2"
++  version = "2.0"
+
+-  broker_node_ebs_volume_size = 20
++  broker_node_storage_info = {
++    ebs_storage_info = { volume_size = 20 }
++  }
+
+-  client_authentication_sasl_scram = true
++  client_authentication = {
++    sasl = { scram = true }
++  }
+
+  tags = {
+    Blueprint  = local.name
+    GithubRepo = "github.com/clowdhaus/terraform-aws-msk-kafka-cluster"
+  }
+}
+```
+
+### State Move Commands
+
+No Terraform state manipulation is required for this upgrade.
+

--- a/examples/basic/README.md
+++ b/examples/basic/README.md
@@ -22,12 +22,14 @@ Note that this example may create resources which will incur monetary charges on
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.71 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0 |
 
 ## Providers
 
-No providers.
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.0 |
 
 ## Modules
 
@@ -35,12 +37,14 @@ No providers.
 |------|--------|---------|
 | <a name="module_msk_cluster"></a> [msk\_cluster](#module\_msk\_cluster) | ../.. | n/a |
 | <a name="module_msk_cluster_disabled"></a> [msk\_cluster\_disabled](#module\_msk\_cluster\_disabled) | ../.. | n/a |
-| <a name="module_security_group"></a> [security\_group](#module\_security\_group) | terraform-aws-modules/security-group/aws | ~> 4.0 |
-| <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-aws-modules/vpc/aws | ~> 3.0 |
+| <a name="module_security_group"></a> [security\_group](#module\_security\_group) | terraform-aws-modules/security-group/aws | ~> 5.0 |
+| <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-aws-modules/vpc/aws | ~> 5.0 |
 
 ## Resources
 
-No resources.
+| Name | Type |
+|------|------|
+| [aws_availability_zones.available](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/availability_zones) | data source |
 
 ## Inputs
 

--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -2,61 +2,38 @@ provider "aws" {
   region = local.region
 }
 
+data "aws_availability_zones" "available" {}
+
 locals {
+  name   = "ex-${basename(path.cwd)}"
   region = "us-east-1"
-  name   = "ex-${replace(basename(path.cwd), "_", "-")}"
+
+  vpc_cidr = "10.0.0.0/16"
+  azs      = slice(data.aws_availability_zones.available.names, 0, 3)
 
   tags = {
-    Example     = local.name
-    Environment = "dev"
+    Example    = local.name
+    GithubRepo = "terraform-aws-msk-kafka-cluster"
+    GithubOrg  = "terraform-aws-modules"
   }
 }
 
 ################################################################################
-# Supporting Resources
+# MSK Cluster - Default
 ################################################################################
 
-module "vpc" {
-  source  = "terraform-aws-modules/vpc/aws"
-  version = "~> 3.0"
+module "msk_cluster" {
+  source = "../.."
 
-  name = local.name
-  cidr = "10.0.0.0/18"
+  name                   = local.name
+  kafka_version          = "3.4.0"
+  number_of_broker_nodes = 3
 
-  azs              = ["${local.region}a", "${local.region}b", "${local.region}c"]
-  public_subnets   = ["10.0.0.0/24", "10.0.1.0/24", "10.0.2.0/24"]
-  private_subnets  = ["10.0.3.0/24", "10.0.4.0/24", "10.0.5.0/24"]
-  database_subnets = ["10.0.7.0/24", "10.0.8.0/24", "10.0.9.0/24"]
-
-  create_database_subnet_group = true
-  enable_nat_gateway           = true
-  single_nat_gateway           = true
-  map_public_ip_on_launch      = false
-
-  manage_default_security_group  = true
-  default_security_group_ingress = []
-  default_security_group_egress  = []
-
-  enable_flow_log                      = true
-  flow_log_destination_type            = "cloud-watch-logs"
-  create_flow_log_cloudwatch_log_group = true
-  create_flow_log_cloudwatch_iam_role  = true
-  flow_log_max_aggregation_interval    = 60
-  flow_log_log_format                  = "$${version} $${account-id} $${interface-id} $${srcaddr} $${dstaddr} $${srcport} $${dstport} $${protocol} $${packets} $${bytes} $${start} $${end} $${action} $${log-status} $${vpc-id} $${subnet-id} $${instance-id} $${tcp-flags} $${type} $${pkt-srcaddr} $${pkt-dstaddr} $${region} $${az-id} $${sublocation-type} $${sublocation-id}"
+  broker_node_client_subnets  = module.vpc.private_subnets
+  broker_node_instance_type   = "kafka.t3.small"
+  broker_node_security_groups = [module.security_group.security_group_id]
 
   tags = local.tags
-}
-
-module "security_group" {
-  source  = "terraform-aws-modules/security-group/aws"
-  version = "~> 4.0"
-
-  name        = local.name
-  description = "Security group for ${local.name}"
-  vpc_id      = module.vpc.vpc_id
-
-  ingress_cidr_blocks = module.vpc.private_subnets_cidr_blocks
-  ingress_rules       = ["kafka-broker-tcp", "kafka-broker-tls-tcp"]
 }
 
 ################################################################################
@@ -70,20 +47,41 @@ module "msk_cluster_disabled" {
 }
 
 ################################################################################
-# MSK Cluster - Default
+# Supporting Resources
 ################################################################################
 
-module "msk_cluster" {
-  source = "../.."
+module "vpc" {
+  source  = "terraform-aws-modules/vpc/aws"
+  version = "~> 5.0"
 
-  name                   = local.name
-  kafka_version          = "2.8.0"
-  number_of_broker_nodes = 3
+  name = local.name
+  cidr = local.vpc_cidr
 
-  broker_node_client_subnets  = module.vpc.private_subnets
-  broker_node_ebs_volume_size = 20
-  broker_node_instance_type   = "kafka.t3.small"
-  broker_node_security_groups = [module.security_group.security_group_id]
+  azs              = local.azs
+  public_subnets   = [for k, v in local.azs : cidrsubnet(local.vpc_cidr, 8, k)]
+  private_subnets  = [for k, v in local.azs : cidrsubnet(local.vpc_cidr, 8, k + 3)]
+  database_subnets = [for k, v in local.azs : cidrsubnet(local.vpc_cidr, 8, k + 6)]
+
+  create_database_subnet_group = true
+  enable_nat_gateway           = true
+  single_nat_gateway           = true
+
+  tags = local.tags
+}
+
+module "security_group" {
+  source  = "terraform-aws-modules/security-group/aws"
+  version = "~> 5.0"
+
+  name        = local.name
+  description = "Security group for ${local.name}"
+  vpc_id      = module.vpc.vpc_id
+
+  ingress_cidr_blocks = module.vpc.private_subnets_cidr_blocks
+  ingress_rules = [
+    "kafka-broker-tcp",
+    "kafka-broker-tls-tcp"
+  ]
 
   tags = local.tags
 }

--- a/examples/basic/versions.tf
+++ b/examples/basic/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = ">= 0.13.1"
+  required_version = ">= 1.0"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.71"
+      version = ">= 5.0"
     }
   }
 }

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -21,15 +21,15 @@ Note that this example may create resources which will incur monetary charges on
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.71 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 2.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.71 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | >= 2.0 |
 
 ## Modules
@@ -37,9 +37,9 @@ Note that this example may create resources which will incur monetary charges on
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_msk_cluster"></a> [msk\_cluster](#module\_msk\_cluster) | ../.. | n/a |
-| <a name="module_s3_logs_bucket"></a> [s3\_logs\_bucket](#module\_s3\_logs\_bucket) | terraform-aws-modules/s3-bucket/aws | ~> 2.0 |
-| <a name="module_security_group"></a> [security\_group](#module\_security\_group) | terraform-aws-modules/security-group/aws | ~> 4.0 |
-| <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-aws-modules/vpc/aws | ~> 3.0 |
+| <a name="module_s3_logs_bucket"></a> [s3\_logs\_bucket](#module\_s3\_logs\_bucket) | terraform-aws-modules/s3-bucket/aws | ~> 3.0 |
+| <a name="module_security_group"></a> [security\_group](#module\_security\_group) | terraform-aws-modules/security-group/aws | ~> 5.0 |
+| <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-aws-modules/vpc/aws | ~> 5.0 |
 
 ## Resources
 
@@ -50,8 +50,7 @@ Note that this example may create resources which will incur monetary charges on
 | [aws_secretsmanager_secret_policy.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret_policy) | resource |
 | [aws_secretsmanager_secret_version.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret_version) | resource |
 | [random_pet.this](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/pet) | resource |
-| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
-| [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
+| [aws_availability_zones.available](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/availability_zones) | data source |
 
 ## Inputs
 

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -2,22 +2,118 @@ provider "aws" {
   region = local.region
 }
 
-locals {
-  region = "us-east-1"
-  name   = "ex-${replace(basename(path.cwd), "_", "-")}"
+data "aws_availability_zones" "available" {}
 
-  secrets        = ["producer", "consumer"]
-  bucket_postfix = "${data.aws_caller_identity.current.account_id}-${data.aws_region.current.name}"
+locals {
+  name   = "ex-${basename(path.cwd)}"
+  region = "us-east-1"
+
+  vpc_cidr = "10.0.0.0/16"
+  azs      = slice(data.aws_availability_zones.available.names, 0, 3)
+
+  secrets = ["producer", "consumer"]
 
   tags = {
-    Example     = local.name
-    Environment = "dev"
+    Example    = local.name
+    GithubRepo = "terraform-aws-msk-kafka-cluster"
+    GithubOrg  = "terraform-aws-modules"
   }
 }
 
-data "aws_region" "current" {}
+################################################################################
+# MSK Cluster - Complete
+################################################################################
 
-data "aws_caller_identity" "current" {}
+module "msk_cluster" {
+  source = "../.."
+
+  name                   = local.name
+  kafka_version          = "3.4.0"
+  number_of_broker_nodes = 3
+  enhanced_monitoring    = "PER_TOPIC_PER_PARTITION"
+
+  broker_node_client_subnets  = module.vpc.private_subnets
+  broker_node_instance_type   = "kafka.t3.small"
+  broker_node_security_groups = [module.security_group.security_group_id]
+  broker_node_storage_info = {
+    ebs_storage_info = { volume_size = 100 }
+  }
+
+  encryption_in_transit_client_broker = "TLS"
+  encryption_in_transit_in_cluster    = true
+
+  configuration_name        = "complete-example-configuration"
+  configuration_description = "Complete example configuration"
+  configuration_server_properties = {
+    "auto.create.topics.enable" = true
+    "delete.topic.enable"       = true
+  }
+
+  jmx_exporter_enabled    = true
+  node_exporter_enabled   = true
+  cloudwatch_logs_enabled = true
+  s3_logs_enabled         = true
+  s3_logs_bucket          = module.s3_logs_bucket.s3_bucket_id
+  s3_logs_prefix          = local.name
+
+  scaling_max_capacity = 512
+  scaling_target_value = 80
+
+  client_authentication = {
+    sasl = { scram = true }
+  }
+  create_scram_secret_association          = true
+  scram_secret_association_secret_arn_list = [for x in aws_secretsmanager_secret.this : x.arn]
+
+  # schema registry
+  schema_registries = {
+    team_a = {
+      name        = "team_a"
+      description = "Schema registry for Team A"
+    }
+    team_b = {
+      name        = "team_b"
+      description = "Schema registry for Team B"
+    }
+  }
+  schemas = {
+    team_a_tweets = {
+      schema_registry_name = "team_a"
+      schema_name          = "tweets"
+      description          = "Schema that contains all the tweets"
+      compatibility        = "FORWARD"
+      schema_definition    = "{\"type\": \"record\", \"name\": \"r1\", \"fields\": [ {\"name\": \"f1\", \"type\": \"int\"}, {\"name\": \"f2\", \"type\": \"string\"} ]}"
+      tags                 = { Team = "Team A" }
+    }
+    team_b_records = {
+      schema_registry_name = "team_b"
+      schema_name          = "records"
+      description          = "Schema that contains all the records"
+      compatibility        = "FORWARD"
+      schema_definition = jsonencode({
+        type = "record"
+        name = "r1"
+        fields = [
+          {
+            name = "f1"
+            type = "int"
+          },
+          {
+            name = "f2"
+            type = "string"
+          },
+          {
+            name = "f3"
+            type = "boolean"
+          }
+        ]
+      })
+      tags = { Team = "Team B" }
+    }
+  }
+
+  tags = local.tags
+}
 
 ################################################################################
 # Supporting Resources
@@ -29,45 +125,38 @@ resource "random_pet" "this" {
 
 module "vpc" {
   source  = "terraform-aws-modules/vpc/aws"
-  version = "~> 3.0"
+  version = "~> 5.0"
 
   name = local.name
-  cidr = "10.0.0.0/18"
+  cidr = local.vpc_cidr
 
-  azs              = ["${local.region}a", "${local.region}b", "${local.region}c"]
-  public_subnets   = ["10.0.0.0/24", "10.0.1.0/24", "10.0.2.0/24"]
-  private_subnets  = ["10.0.3.0/24", "10.0.4.0/24", "10.0.5.0/24"]
-  database_subnets = ["10.0.7.0/24", "10.0.8.0/24", "10.0.9.0/24"]
+  azs              = local.azs
+  public_subnets   = [for k, v in local.azs : cidrsubnet(local.vpc_cidr, 8, k)]
+  private_subnets  = [for k, v in local.azs : cidrsubnet(local.vpc_cidr, 8, k + 3)]
+  database_subnets = [for k, v in local.azs : cidrsubnet(local.vpc_cidr, 8, k + 6)]
 
   create_database_subnet_group = true
   enable_nat_gateway           = true
   single_nat_gateway           = true
-  map_public_ip_on_launch      = false
-
-  manage_default_security_group  = true
-  default_security_group_ingress = []
-  default_security_group_egress  = []
-
-  enable_flow_log                      = true
-  flow_log_destination_type            = "cloud-watch-logs"
-  create_flow_log_cloudwatch_log_group = true
-  create_flow_log_cloudwatch_iam_role  = true
-  flow_log_max_aggregation_interval    = 60
-  flow_log_log_format                  = "$${version} $${account-id} $${interface-id} $${srcaddr} $${dstaddr} $${srcport} $${dstport} $${protocol} $${packets} $${bytes} $${start} $${end} $${action} $${log-status} $${vpc-id} $${subnet-id} $${instance-id} $${tcp-flags} $${type} $${pkt-srcaddr} $${pkt-dstaddr} $${region} $${az-id} $${sublocation-type} $${sublocation-id}"
 
   tags = local.tags
 }
 
 module "security_group" {
   source  = "terraform-aws-modules/security-group/aws"
-  version = "~> 4.0"
+  version = "~> 5.0"
 
   name        = local.name
   description = "Security group for ${local.name}"
   vpc_id      = module.vpc.vpc_id
 
   ingress_cidr_blocks = module.vpc.private_subnets_cidr_blocks
-  ingress_rules       = ["kafka-broker-tcp", "kafka-broker-tls-tcp"]
+  ingress_rules = [
+    "kafka-broker-tcp",
+    "kafka-broker-tls-tcp"
+  ]
+
+  tags = local.tags
 }
 
 resource "aws_kms_key" "this" {
@@ -119,10 +208,14 @@ resource "aws_secretsmanager_secret_policy" "this" {
 
 module "s3_logs_bucket" {
   source  = "terraform-aws-modules/s3-bucket/aws"
-  version = "~> 2.0"
+  version = "~> 3.0"
 
-  bucket = "${local.name}-${local.bucket_postfix}"
-  acl    = "log-delivery-write"
+  bucket_prefix = local.name
+
+  acl                      = "log-delivery-write"
+  control_object_ownership = true
+  object_ownership         = "ObjectWriter"
+
 
   # Allow deletion of non-empty bucket for testing
   force_destroy = true
@@ -130,103 +223,11 @@ module "s3_logs_bucket" {
   attach_deny_insecure_transport_policy = true
   attach_lb_log_delivery_policy         = true # this allows log delivery
 
-  block_public_acls       = true
-  block_public_policy     = true
-  ignore_public_acls      = true
-  restrict_public_buckets = true
-
   server_side_encryption_configuration = {
     rule = {
       apply_server_side_encryption_by_default = {
         sse_algorithm = "AES256"
       }
-    }
-  }
-
-  tags = local.tags
-}
-
-################################################################################
-# MSK Cluster - Complete
-################################################################################
-
-module "msk_cluster" {
-  source = "../.."
-
-  name                   = local.name
-  kafka_version          = "2.8.0"
-  number_of_broker_nodes = 3
-  enhanced_monitoring    = "PER_TOPIC_PER_PARTITION"
-
-  broker_node_client_subnets  = module.vpc.private_subnets
-  broker_node_ebs_volume_size = 20
-  broker_node_instance_type   = "kafka.t3.small"
-  broker_node_security_groups = [module.security_group.security_group_id]
-
-  encryption_in_transit_client_broker = "TLS"
-  encryption_in_transit_in_cluster    = true
-
-  configuration_name        = "complete-example-configuration"
-  configuration_description = "Complete example configuration"
-  configuration_server_properties = {
-    "auto.create.topics.enable" = true
-    "delete.topic.enable"       = true
-  }
-
-  jmx_exporter_enabled    = true
-  node_exporter_enabled   = true
-  cloudwatch_logs_enabled = true
-  s3_logs_enabled         = true
-  s3_logs_bucket          = module.s3_logs_bucket.s3_bucket_id
-  s3_logs_prefix          = local.name
-
-  scaling_max_capacity = 512
-  scaling_target_value = 80
-
-  client_authentication_sasl_scram         = true
-  create_scram_secret_association          = true
-  scram_secret_association_secret_arn_list = [for x in aws_secretsmanager_secret.this : x.arn]
-
-  # schema registry
-  schema_registries = {
-    team_a = {
-      name        = "team_a"
-      description = "Schema registry for Team A"
-    }
-    team_b = {
-      name        = "team_b"
-      description = "Schema registry for Team B"
-    }
-  }
-  schemas = {
-    team_a_tweets = {
-      schema_registry_name = "team_a"
-      schema_name          = "tweets"
-      description          = "Schema that contains all the tweets"
-      compatibility        = "FORWARD"
-      schema_definition    = "{\"type\": \"record\", \"name\": \"r1\", \"fields\": [ {\"name\": \"f1\", \"type\": \"int\"}, {\"name\": \"f2\", \"type\": \"string\"} ]}"
-      tags                 = { Team = "Team A" }
-    }
-    team_b_records = {
-      schema_registry_name = "team_b"
-      schema_name          = "records"
-      description          = "Schema that contains all the records"
-      compatibility        = "FORWARD"
-      schema_definition = jsonencode({
-        type = "record"
-        name = "r1"
-        fields = [{
-          name = "f1"
-          type = "int"
-          }, {
-          name = "f2"
-          type = "string"
-          }, {
-          name = "f3"
-          type = "boolean"
-        }]
-      })
-      tags = { Team = "Team B" }
     }
   }
 

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = ">= 0.13.1"
+  required_version = ">= 1.0"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.71"
+      version = ">= 5.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/connect/README.md
+++ b/examples/connect/README.md
@@ -21,15 +21,15 @@ Note that this example may create resources which will incur monetary charges on
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.71 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | >= 3.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.71 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.0 |
 | <a name="provider_null"></a> [null](#provider\_null) | >= 3.0 |
 
 ## Modules
@@ -37,18 +37,17 @@ Note that this example may create resources which will incur monetary charges on
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_msk_cluster"></a> [msk\_cluster](#module\_msk\_cluster) | ../.. | n/a |
-| <a name="module_s3_bucket"></a> [s3\_bucket](#module\_s3\_bucket) | terraform-aws-modules/s3-bucket/aws | ~> 2.0 |
-| <a name="module_security_group"></a> [security\_group](#module\_security\_group) | terraform-aws-modules/security-group/aws | ~> 4.0 |
-| <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-aws-modules/vpc/aws | ~> 3.0 |
+| <a name="module_s3_bucket"></a> [s3\_bucket](#module\_s3\_bucket) | terraform-aws-modules/s3-bucket/aws | ~> 3.0 |
+| <a name="module_security_group"></a> [security\_group](#module\_security\_group) | terraform-aws-modules/security-group/aws | ~> 5.0 |
+| <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-aws-modules/vpc/aws | ~> 5.0 |
 
 ## Resources
 
 | Name | Type |
 |------|------|
-| [aws_s3_bucket_object.debezium_connector](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_object) | resource |
+| [aws_s3_object.debezium_connector](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_object) | resource |
 | [null_resource.debezium_connector](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
-| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
-| [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
+| [aws_availability_zones.available](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/availability_zones) | data source |
 
 ## Inputs
 

--- a/examples/connect/main.tf
+++ b/examples/connect/main.tf
@@ -2,121 +2,22 @@ provider "aws" {
   region = local.region
 }
 
+data "aws_availability_zones" "available" {}
+
 locals {
+  name   = "ex-${basename(path.cwd)}"
   region = "us-east-1"
-  name   = "ex-${replace(basename(path.cwd), "_", "-")}"
 
-  bucket_postfix = "${data.aws_caller_identity.current.account_id}-${data.aws_region.current.name}"
+  vpc_cidr = "10.0.0.0/16"
+  azs      = slice(data.aws_availability_zones.available.names, 0, 3)
 
-  connector_external_url = "https://repo1.maven.org/maven2/io/debezium/debezium-connector-postgres/1.8.0.Final/debezium-connector-postgres-1.8.0.Final-plugin.tar.gz"
-  connector              = "debezium-connector-postgres/debezium-connector-postgres-1.8.0.Final.jar"
+  connector_external_url = "https://repo1.maven.org/maven2/io/debezium/debezium-connector-postgres/2.3.0.Final/debezium-connector-postgres-2.3.0.Final-plugin.tar.gz"
+  connector              = "debezium-connector-postgres/debezium-connector-postgres-2.3.0.Final.jar"
 
   tags = {
-    Example     = local.name
-    Environment = "dev"
-  }
-}
-
-data "aws_region" "current" {}
-
-data "aws_caller_identity" "current" {}
-
-################################################################################
-# Supporting Resources
-################################################################################
-
-module "vpc" {
-  source  = "terraform-aws-modules/vpc/aws"
-  version = "~> 3.0"
-
-  name = local.name
-  cidr = "10.0.0.0/18"
-
-  azs              = ["${local.region}a", "${local.region}b", "${local.region}c"]
-  public_subnets   = ["10.0.0.0/24", "10.0.1.0/24", "10.0.2.0/24"]
-  private_subnets  = ["10.0.3.0/24", "10.0.4.0/24", "10.0.5.0/24"]
-  database_subnets = ["10.0.7.0/24", "10.0.8.0/24", "10.0.9.0/24"]
-
-  create_database_subnet_group = true
-  enable_nat_gateway           = true
-  single_nat_gateway           = true
-  map_public_ip_on_launch      = false
-
-  manage_default_security_group  = true
-  default_security_group_ingress = []
-  default_security_group_egress  = []
-
-  enable_flow_log                      = true
-  flow_log_destination_type            = "cloud-watch-logs"
-  create_flow_log_cloudwatch_log_group = true
-  create_flow_log_cloudwatch_iam_role  = true
-  flow_log_max_aggregation_interval    = 60
-  flow_log_log_format                  = "$${version} $${account-id} $${interface-id} $${srcaddr} $${dstaddr} $${srcport} $${dstport} $${protocol} $${packets} $${bytes} $${start} $${end} $${action} $${log-status} $${vpc-id} $${subnet-id} $${instance-id} $${tcp-flags} $${type} $${pkt-srcaddr} $${pkt-dstaddr} $${region} $${az-id} $${sublocation-type} $${sublocation-id}"
-
-  tags = local.tags
-}
-
-module "security_group" {
-  source  = "terraform-aws-modules/security-group/aws"
-  version = "~> 4.0"
-
-  name        = local.name
-  description = "Security group for ${local.name}"
-  vpc_id      = module.vpc.vpc_id
-
-  ingress_cidr_blocks = module.vpc.private_subnets_cidr_blocks
-  ingress_rules       = ["kafka-broker-tcp", "kafka-broker-tls-tcp"]
-}
-
-module "s3_bucket" {
-  source  = "terraform-aws-modules/s3-bucket/aws"
-  version = "~> 2.0"
-
-  bucket = "${local.name}-${local.bucket_postfix}"
-  acl    = "private"
-
-  versioning = {
-    enabled = true
-  }
-
-  # Allow deletion of non-empty bucket for testing
-  force_destroy = true
-
-  attach_deny_insecure_transport_policy = true
-
-  block_public_acls       = true
-  block_public_policy     = true
-  ignore_public_acls      = true
-  restrict_public_buckets = true
-
-  server_side_encryption_configuration = {
-    rule = {
-      apply_server_side_encryption_by_default = {
-        sse_algorithm = "AES256"
-      }
-    }
-  }
-
-  tags = local.tags
-}
-
-resource "aws_s3_bucket_object" "debezium_connector" {
-  bucket = module.s3_bucket.s3_bucket_id
-  key    = local.connector
-  source = local.connector
-
-  depends_on = [
-    null_resource.debezium_connector
-  ]
-}
-
-resource "null_resource" "debezium_connector" {
-  provisioner "local-exec" {
-    command = <<-EOT
-    wget -c ${local.connector_external_url} -O connector.tar.gz \
-    && tar -zxvf connector.tar.gz  ${local.connector} \
-    && rm *.tar.gz
-    EOT
+    Example    = local.name
+    GithubRepo = "terraform-aws-msk-kafka-cluster"
+    GithubOrg  = "terraform-aws-modules"
   }
 }
 
@@ -128,11 +29,10 @@ module "msk_cluster" {
   source = "../.."
 
   name                   = local.name
-  kafka_version          = "2.8.0"
+  kafka_version          = "3.4.0"
   number_of_broker_nodes = 3
 
   broker_node_client_subnets  = module.vpc.private_subnets
-  broker_node_ebs_volume_size = 20
   broker_node_instance_type   = "kafka.t3.small"
   broker_node_security_groups = [module.security_group.security_group_id]
 
@@ -144,8 +44,8 @@ module "msk_cluster" {
       content_type = "JAR"
 
       s3_bucket_arn     = module.s3_bucket.s3_bucket_arn
-      s3_file_key       = aws_s3_bucket_object.debezium_connector.id
-      s3_object_version = aws_s3_bucket_object.debezium_connector.version_id
+      s3_file_key       = aws_s3_object.debezium_connector.id
+      s3_object_version = aws_s3_object.debezium_connector.version_id
 
       timeouts = {
         create = "20m"
@@ -158,9 +58,95 @@ module "msk_cluster" {
   connect_worker_config_name                    = local.name
   connect_worker_config_description             = "Example connect worker configuration"
   connect_worker_config_properties_file_content = <<-EOT
-  key.converter=org.apache.kafka.connect.storage.StringConverter
-  value.converter=org.apache.kafka.connect.storage.StringConverter
+    key.converter=org.apache.kafka.connect.storage.StringConverter
+    value.converter=org.apache.kafka.connect.storage.StringConverter
   EOT
 
   tags = local.tags
+}
+
+################################################################################
+# Supporting Resources
+################################################################################
+
+module "vpc" {
+  source  = "terraform-aws-modules/vpc/aws"
+  version = "~> 5.0"
+
+  name = local.name
+  cidr = local.vpc_cidr
+
+  azs              = local.azs
+  public_subnets   = [for k, v in local.azs : cidrsubnet(local.vpc_cidr, 8, k)]
+  private_subnets  = [for k, v in local.azs : cidrsubnet(local.vpc_cidr, 8, k + 3)]
+  database_subnets = [for k, v in local.azs : cidrsubnet(local.vpc_cidr, 8, k + 6)]
+
+  create_database_subnet_group = true
+  enable_nat_gateway           = true
+  single_nat_gateway           = true
+
+  tags = local.tags
+}
+
+module "security_group" {
+  source  = "terraform-aws-modules/security-group/aws"
+  version = "~> 5.0"
+
+  name        = local.name
+  description = "Security group for ${local.name}"
+  vpc_id      = module.vpc.vpc_id
+
+  ingress_cidr_blocks = module.vpc.private_subnets_cidr_blocks
+  ingress_rules = [
+    "kafka-broker-tcp",
+    "kafka-broker-tls-tcp"
+  ]
+
+  tags = local.tags
+}
+
+module "s3_bucket" {
+  source  = "terraform-aws-modules/s3-bucket/aws"
+  version = "~> 3.0"
+
+  bucket_prefix = local.name
+  acl           = "private"
+
+  versioning = {
+    enabled = true
+  }
+
+  # Allow deletion of non-empty bucket for testing
+  force_destroy = true
+
+  attach_deny_insecure_transport_policy = true
+  server_side_encryption_configuration = {
+    rule = {
+      apply_server_side_encryption_by_default = {
+        sse_algorithm = "AES256"
+      }
+    }
+  }
+
+  tags = local.tags
+}
+
+resource "aws_s3_object" "debezium_connector" {
+  bucket = module.s3_bucket.s3_bucket_id
+  key    = local.connector
+  source = local.connector
+
+  depends_on = [
+    null_resource.debezium_connector
+  ]
+}
+
+resource "null_resource" "debezium_connector" {
+  provisioner "local-exec" {
+    command = <<-EOT
+      wget -c ${local.connector_external_url} -O connector.tar.gz \
+        && tar -zxvf connector.tar.gz  ${local.connector} \
+        && rm *.tar.gz
+    EOT
+  }
 }

--- a/examples/connect/versions.tf
+++ b/examples/connect/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = ">= 0.13.1"
+  required_version = ">= 1.0"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.71"
+      version = ">= 5.0"
     }
     null = {
       source  = "hashicorp/null"

--- a/outputs.tf
+++ b/outputs.tf
@@ -4,52 +4,52 @@
 
 output "arn" {
   description = "Amazon Resource Name (ARN) of the MSK cluster"
-  value       = try(aws_msk_cluster.this[0].arn, "")
+  value       = try(aws_msk_cluster.this[0].arn, null)
 }
 
 output "bootstrap_brokers" {
   description = "Comma separated list of one or more hostname:port pairs of kafka brokers suitable to bootstrap connectivity to the kafka cluster"
   value = compact([
-    try(aws_msk_cluster.this[0].bootstrap_brokers, ""),
-    try(aws_msk_cluster.this[0].bootstrap_brokers_sasl_iam, ""),
-    try(aws_msk_cluster.this[0].bootstrap_brokers_sasl_scram, ""),
-    try(aws_msk_cluster.this[0].bootstrap_brokers_tls, ""),
+    try(aws_msk_cluster.this[0].bootstrap_brokers, null),
+    try(aws_msk_cluster.this[0].bootstrap_brokers_sasl_iam, null),
+    try(aws_msk_cluster.this[0].bootstrap_brokers_sasl_scram, null),
+    try(aws_msk_cluster.this[0].bootstrap_brokers_tls, null),
   ])
 }
 
 output "bootstrap_brokers_plaintext" {
   description = "Comma separated list of one or more hostname:port pairs of kafka brokers suitable to bootstrap connectivity to the kafka cluster. Contains a value if `encryption_in_transit_client_broker` is set to `PLAINTEXT` or `TLS_PLAINTEXT`"
-  value       = try(aws_msk_cluster.this[0].bootstrap_brokers, "")
+  value       = try(aws_msk_cluster.this[0].bootstrap_brokers, null)
 }
 
 output "bootstrap_brokers_sasl_iam" {
   description = "One or more DNS names (or IP addresses) and SASL IAM port pairs. This attribute will have a value if `encryption_in_transit_client_broker` is set to `TLS_PLAINTEXT` or `TLS` and `client_authentication_sasl_iam` is set to `true`"
-  value       = try(aws_msk_cluster.this[0].bootstrap_brokers_sasl_iam, "")
+  value       = try(aws_msk_cluster.this[0].bootstrap_brokers_sasl_iam, null)
 }
 
 output "bootstrap_brokers_sasl_scram" {
   description = "One or more DNS names (or IP addresses) and SASL SCRAM port pairs. This attribute will have a value if `encryption_in_transit_client_broker` is set to `TLS_PLAINTEXT` or `TLS` and `client_authentication_sasl_scram` is set to `true`"
-  value       = try(aws_msk_cluster.this[0].bootstrap_brokers_sasl_scram, "")
+  value       = try(aws_msk_cluster.this[0].bootstrap_brokers_sasl_scram, null)
 }
 
 output "bootstrap_brokers_tls" {
   description = "One or more DNS names (or IP addresses) and TLS port pairs. This attribute will have a value if `encryption_in_transit_client_broker` is set to `TLS_PLAINTEXT` or `TLS`"
-  value       = try(aws_msk_cluster.this[0].bootstrap_brokers_tls, "")
+  value       = try(aws_msk_cluster.this[0].bootstrap_brokers_tls, null)
 }
 
 output "current_version" {
   description = "Current version of the MSK Cluster used for updates, e.g. `K13V1IB3VIYZZH`"
-  value       = try(aws_msk_cluster.this[0].current_version, "")
+  value       = try(aws_msk_cluster.this[0].current_version, null)
 }
 
 output "zookeeper_connect_string" {
   description = "A comma separated list of one or more hostname:port pairs to use to connect to the Apache Zookeeper cluster. The returned values are sorted alphabetically"
-  value       = try(aws_msk_cluster.this[0].zookeeper_connect_string, "")
+  value       = try(aws_msk_cluster.this[0].zookeeper_connect_string, null)
 }
 
 output "zookeeper_connect_string_tls" {
   description = "A comma separated list of one or more hostname:port pairs to use to connect to the Apache Zookeeper cluster via TLS. The returned values are sorted alphabetically"
-  value       = try(aws_msk_cluster.this[0].zookeeper_connect_string_tls, "")
+  value       = try(aws_msk_cluster.this[0].zookeeper_connect_string_tls, null)
 }
 
 ################################################################################
@@ -58,12 +58,12 @@ output "zookeeper_connect_string_tls" {
 
 output "configuration_arn" {
   description = "Amazon Resource Name (ARN) of the configuration"
-  value       = try(aws_msk_configuration.this[0].arn, "")
+  value       = try(aws_msk_configuration.this[0].arn, null)
 }
 
 output "configuration_latest_revision" {
   description = "Latest revision of the configuration"
-  value       = try(aws_msk_configuration.this[0].latest_revision, "")
+  value       = try(aws_msk_configuration.this[0].latest_revision, null)
 }
 
 ################################################################################
@@ -72,7 +72,7 @@ output "configuration_latest_revision" {
 
 output "scram_secret_association_id" {
   description = "Amazon Resource Name (ARN) of the MSK cluster"
-  value       = try(aws_msk_scram_secret_association.this[0].id, "")
+  value       = try(aws_msk_scram_secret_association.this[0].id, null)
 }
 
 ################################################################################
@@ -81,7 +81,7 @@ output "scram_secret_association_id" {
 
 output "log_group_arn" {
   description = "The Amazon Resource Name (ARN) specifying the log group"
-  value       = try(aws_cloudwatch_log_group.this[0].arn, "")
+  value       = try(aws_cloudwatch_log_group.this[0].arn, null)
 }
 
 ################################################################################
@@ -90,17 +90,17 @@ output "log_group_arn" {
 
 output "appautoscaling_policy_arn" {
   description = "The ARN assigned by AWS to the scaling policy"
-  value       = try(aws_appautoscaling_policy.this[0].arn, "")
+  value       = try(aws_appautoscaling_policy.this[0].arn, null)
 }
 
 output "appautoscaling_policy_name" {
   description = "The scaling policy's name"
-  value       = try(aws_appautoscaling_policy.this[0].name, "")
+  value       = try(aws_appautoscaling_policy.this[0].name, null)
 }
 
 output "appautoscaling_policy_policy_type" {
   description = "The scaling policy's type"
-  value       = try(aws_appautoscaling_policy.this[0].policy_type, "")
+  value       = try(aws_appautoscaling_policy.this[0].policy_type, null)
 }
 
 ################################################################################
@@ -132,10 +132,10 @@ output "connect_custom_plugins" {
 
 output "connect_worker_configuration_arn" {
   description = "The Amazon Resource Name (ARN) of the worker configuration"
-  value       = try(aws_mskconnect_worker_configuration.this[0].arn, "")
+  value       = try(aws_mskconnect_worker_configuration.this[0].arn, null)
 }
 
 output "connect_worker_configuration_latest_revision" {
   description = "An ID of the latest successfully created revision of the worker configuration"
-  value       = try(aws_mskconnect_worker_configuration.this[0].latest_revision, "")
+  value       = try(aws_mskconnect_worker_configuration.this[0].latest_revision, null)
 }

--- a/variables.tf
+++ b/variables.tf
@@ -4,30 +4,18 @@ variable "create" {
   default     = true
 }
 
+variable "tags" {
+  description = "A map of tags to assign to the resources created"
+  type        = map(string)
+  default     = {}
+}
+
 ################################################################################
 # Cluster
 ################################################################################
 
-variable "name" {
-  description = "Name of the MSK cluster"
-  type        = string
-  default     = "msk" # to avoid: Error: cluster_name must be 1 characters or higher
-}
-
-variable "kafka_version" {
-  description = "Specify the desired Kafka software version"
-  type        = string
-  default     = null
-}
-
-variable "number_of_broker_nodes" {
-  description = "The desired total number of broker nodes in the kafka cluster. It must be a multiple of the number of specified client subnets"
-  type        = number
-  default     = null
-}
-
-variable "enhanced_monitoring" {
-  description = "Specify the desired enhanced MSK CloudWatch monitoring level. See [Monitoring Amazon MSK with Amazon CloudWatch](https://docs.aws.amazon.com/msk/latest/developerguide/monitoring.html)"
+variable "broker_node_az_distribution" {
+  description = "The distribution of broker nodes across availability zones ([documentation](https://docs.aws.amazon.com/msk/1.0/apireference/clusters.html#clusters-model-brokerazdistribution)). Currently the only valid value is `DEFAULT`"
   type        = string
   default     = null
 }
@@ -38,10 +26,10 @@ variable "broker_node_client_subnets" {
   default     = []
 }
 
-variable "broker_node_ebs_volume_size" {
-  description = "The size in GiB of the EBS volume for the data drive on each broker node"
-  type        = number
-  default     = null
+variable "broker_node_connectivity_info" {
+  description = "Information about the cluster access configuration"
+  type        = any
+  default     = {}
 }
 
 variable "broker_node_instance_type" {
@@ -56,22 +44,28 @@ variable "broker_node_security_groups" {
   default     = []
 }
 
-variable "client_authentication_tls_certificate_authority_arns" {
-  description = "List of ACM Certificate Authority Amazon Resource Names (ARNs)"
-  type        = list(string)
-  default     = []
+variable "broker_node_storage_info" {
+  description = "A block that contains information about storage volumes attached to MSK broker nodes"
+  type        = any
+  default     = {}
 }
 
-variable "client_authentication_sasl_iam" {
-  description = "Enables IAM client authentication"
-  type        = bool
-  default     = false
+variable "client_authentication" {
+  description = "Configuration block for specifying a client authentication"
+  type        = any
+  default     = {}
 }
 
-variable "client_authentication_sasl_scram" {
-  description = "Enables SCRAM client authentication via AWS Secrets Manager"
-  type        = bool
-  default     = false
+variable "name" {
+  description = "Name of the MSK cluster"
+  type        = string
+  default     = "msk" # to avoid: Error: cluster_name must be 1 characters or higher
+}
+
+variable "encryption_at_rest_kms_key_arn" {
+  description = "You may specify a KMS key short ID or ARN (it will always output an ARN) to use for encrypting your data at rest. If no key is specified, an AWS managed KMS ('aws/msk' managed service) key will be used for encrypting the data at rest"
+  type        = string
+  default     = null
 }
 
 variable "encryption_in_transit_client_broker" {
@@ -86,22 +80,16 @@ variable "encryption_in_transit_in_cluster" {
   default     = null
 }
 
-variable "encryption_at_rest_kms_key_arn" {
-  description = "You may specify a KMS key short ID or ARN (it will always output an ARN) to use for encrypting your data at rest. If no key is specified, an AWS managed KMS ('aws/msk' managed service) key will be used for encrypting the data at rest"
+variable "enhanced_monitoring" {
+  description = "Specify the desired enhanced MSK CloudWatch monitoring level. See [Monitoring Amazon MSK with Amazon CloudWatch](https://docs.aws.amazon.com/msk/latest/developerguide/monitoring.html)"
   type        = string
   default     = null
 }
 
-variable "jmx_exporter_enabled" {
-  description = "Indicates whether you want to enable or disable the JMX Exporter"
-  type        = bool
-  default     = false
-}
-
-variable "node_exporter_enabled" {
-  description = "Indicates whether you want to enable or disable the Node Exporter"
-  type        = bool
-  default     = false
+variable "kafka_version" {
+  description = "Specify the desired Kafka software version"
+  type        = string
+  default     = null
 }
 
 variable "cloudwatch_logs_enabled" {
@@ -140,14 +128,32 @@ variable "s3_logs_prefix" {
   default     = null
 }
 
-variable "timeouts" {
-  description = "Create, update, and delete timeout configurations for the cluster"
-  type        = map(string)
-  default     = {}
+variable "number_of_broker_nodes" {
+  description = "The desired total number of broker nodes in the kafka cluster. It must be a multiple of the number of specified client subnets"
+  type        = number
+  default     = null
 }
 
-variable "tags" {
-  description = "A map of tags to assign to the resources created"
+variable "jmx_exporter_enabled" {
+  description = "Indicates whether you want to enable or disable the JMX Exporter"
+  type        = bool
+  default     = false
+}
+
+variable "node_exporter_enabled" {
+  description = "Indicates whether you want to enable or disable the Node Exporter"
+  type        = bool
+  default     = false
+}
+
+variable "storage_mode" {
+  description = "Controls storage mode for supported storage tiers. Valid values are: `LOCAL` or `TIERED`"
+  type        = string
+  default     = null
+}
+
+variable "timeouts" {
+  description = "Create, update, and delete timeout configurations for the cluster"
   type        = map(string)
   default     = {}
 }
@@ -155,6 +161,24 @@ variable "tags" {
 ################################################################################
 # Configuration
 ################################################################################
+
+variable "create_configuration" {
+  description = "Determines whether to create a configuration"
+  type        = bool
+  default     = true
+}
+
+variable "configuration_arn" {
+  description = "ARN of an externally created configuration to use"
+  type        = string
+  default     = null
+}
+
+variable "configuration_revision" {
+  description = "Revision of the externally created configuration to use"
+  type        = number
+  default     = null
+}
 
 variable "configuration_name" {
   description = "Name of the configuration"

--- a/versions.tf
+++ b/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = ">= 0.13.1"
+  required_version = ">= 1.0"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.71"
+      version = ">= 5.0"
     }
   }
 }


### PR DESCRIPTION
## Description
- Terraform AWS provider minimum supported version raised to `v5.0`
- Terraform minimum supported version raised to `v1.0`
- `broker_node_ebs_volume_size` has been removed since the `ebs_volume_size` argument was removed in `v5.0` of the AWS provider. Instead, storage settings should be configured using the `broker_node_storage_info` variable.
- `client_authentication_*` variables have been removed and replaced with `client_authentication` which supports the various authentication methods and configurations

See the [`UPGRADE-2.0.md`](https://github.com/clowdhaus/terraform-aws-msk-kafka-cluster/blob/feat/update/UPGRADE-2.0.md) guide for further details

## Motivation and Context
- Adds support for latest configurations available by the MSK provider resources
- Resolves #3 
- Resolves #4 
- Resolves #7

## How Has This Been Tested?
- Tested using the `complete` example

## Screenshots (if appropriate):
