### PR TITLE
fix: Enable broker log delivery for Express brokers

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -119,25 +119,22 @@ resource "aws_msk_cluster" "this" {
   enhanced_monitoring = var.enhanced_monitoring
   kafka_version       = var.kafka_version
 
-  dynamic "logging_info" {
-    for_each = length(regexall("^express", var.broker_node_instance_type)) > 0 ? [] : [true]
-    content {
-      broker_logs {
-        cloudwatch_logs {
-          enabled   = var.cloudwatch_logs_enabled
-          log_group = var.cloudwatch_logs_enabled ? local.cloudwatch_log_group : null
-        }
+  logging_info {
+    broker_logs {
+      cloudwatch_logs {
+        enabled   = var.cloudwatch_logs_enabled
+        log_group = var.cloudwatch_logs_enabled ? local.cloudwatch_log_group : null
+      }
 
-        firehose {
-          enabled         = var.firehose_logs_enabled
-          delivery_stream = var.firehose_delivery_stream
-        }
+      firehose {
+        enabled         = var.firehose_logs_enabled
+        delivery_stream = var.firehose_delivery_stream
+      }
 
-        s3 {
-          bucket  = var.s3_logs_bucket
-          enabled = var.s3_logs_enabled
-          prefix  = var.s3_logs_prefix
-        }
+      s3 {
+        bucket  = var.s3_logs_bucket
+        enabled = var.s3_logs_enabled
+        prefix  = var.s3_logs_prefix
       }
     }
   }


### PR DESCRIPTION
## Description

Express brokers now support broker log delivery (CloudWatch Logs, Firehose, S3), but the module still restricts the `logging_info` block to Standard brokers, so `cloudwatch_logs_enabled` / `firehose_logs_enabled` / `s3_logs_enabled` are silently ignored on Express clusters.

The Express guard was introduced in #48, back when Express brokers did not accept a `logging_info` block. AWS has since added broker log delivery for Express brokers (https://docs.aws.amazon.com/msk/latest/developerguide/msk-logging.html), so the guard is no longer needed. This reverts the `dynamic "logging_info"` wrapper back to the original static `logging_info` block, applying the same logging configuration to both broker types.

Closes #68

## Validation

- `terraform validate` -> Success! The configuration is valid.
- `pre-commit run --files main.tf` -> terraform_fmt, terraform_docs, terraform_validate, terraform_validate with tflint all pass.

## Breaking Changes

None for Standard brokers (the rendered `logging_info` block is unchanged). Express brokers gain the logging configuration that was previously ignored.
